### PR TITLE
BUGFIX: argh include needed to point to where the source code was stored in _deps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(storyteller PRIVATE SQLiteCpp)
 target_link_libraries(storyteller PRIVATE nlohmann_json::nlohmann_json)
 
 target_link_libraries(storyteller PRIVATE argh)
-# target_include_directories(storyteller PRIVATE argh)
+target_include_directories(storyteller PRIVATE ${argh_INCLUDE_DIR})
 
 # IDEs should put the headers in a nice place
 source_group(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(storyteller PRIVATE SQLiteCpp)
 target_link_libraries(storyteller PRIVATE nlohmann_json::nlohmann_json)
 
 target_link_libraries(storyteller PRIVATE argh)
-target_include_directories(storyteller PUBLIC ${argh_INCLUDE_DIR})
+target_include_directories(storyteller PUBLIC ${argh_SOURCE_DIR})
 
 # IDEs should put the headers in a nice place
 source_group(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(storyteller PRIVATE SQLiteCpp)
 target_link_libraries(storyteller PRIVATE nlohmann_json::nlohmann_json)
 
 target_link_libraries(storyteller PRIVATE argh)
-target_include_directories(storyteller PRIVATE argh)
+# target_include_directories(storyteller PRIVATE argh)
 
 # IDEs should put the headers in a nice place
 source_group(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(storyteller PRIVATE SQLiteCpp)
 target_link_libraries(storyteller PRIVATE nlohmann_json::nlohmann_json)
 
 target_link_libraries(storyteller PRIVATE argh)
-target_include_directories(storyteller PRIVATE ${argh_INCLUDE_DIR})
+target_include_directories(storyteller PUBLIC ${argh_INCLUDE_DIR})
 
 # IDEs should put the headers in a nice place
 source_group(


### PR DESCRIPTION
This was preventing the project from compiling when the library was included in another project.