### PR TITLE
Enforcing that susceptibility is treated as a probability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build
 
 # vscode ignores
 .vscode
+*.code-workspace
 
 # cmake ignores
 CMakeLists.txt.user

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -120,9 +120,9 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_is_co
     description = "",
     flag  = "const",
     datatype = "double",
-    value = 1.0,
+    value = 0.0,
     validate = function(v)
-        local ret = (v == 1.0)
+        local ret = (v == 0.0)
         return ret
     end
 }
@@ -311,8 +311,8 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_baseline"] = 
 }
 
 -- INFLUENZA VACCINE PARAMETERS
-Parameters["parameters"]["influenza_vaccine_effect_distribution_a"] = {
-    nickname = "flu_vax_effect_a",
+Parameters["parameters"]["influenza_vaccine_effect_distribution_is_continuous"] = {
+    nickname = "flu_vax_effect_is_contin",
     description = "",
     flag  = "const",
     datatype = "double",
@@ -323,8 +323,8 @@ Parameters["parameters"]["influenza_vaccine_effect_distribution_a"] = {
     end
 }
 
-Parameters["parameters"]["influenza_vaccine_effect_distribution_b"] = {
-    nickname = "flu_vax_effect_b",
+Parameters["parameters"]["influenza_vaccine_effect_distribution_mean"] = {
+    nickname = "flu_vax_effect_mean",
     description = "",
     flag  = "step",
     datatype = "double",
@@ -337,9 +337,8 @@ Parameters["parameters"]["influenza_vaccine_effect_distribution_b"] = {
     end
 }
 
--- NONINFLUENZA VACCINE PARAMETERS
-Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_a"] = {
-    nickname = "nonflu_vax_effect_a",
+Parameters["parameters"]["influenza_vaccine_effect_distribution_variance"] = {
+    nickname = "flu_vax_effect_var",
     description = "",
     flag  = "const",
     datatype = "double",
@@ -350,8 +349,33 @@ Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_a"] = {
     end
 }
 
-Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_b"] = {
-    nickname = "nonflu_vax_effect_b",
+-- NONINFLUENZA VACCINE PARAMETERS
+Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_is_continuous"] = {
+    nickname = "nonflu_vax_effect_is_contin",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_mean"] = {
+    nickname = "nonflu_vax_effect_mean",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_variance"] = {
+    nickname = "nonflu_vax_effect_var",
     description = "",
     flag  = "const",
     datatype = "double",

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -127,18 +127,6 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_is_co
     end
 }
 
-Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_variance"] = {
-    nickname = "vaxd_flu_suscep_var",
-    description = "",
-    flag  = "const",
-    datatype = "double",
-    value = 1e-4,
-    validate = function(v)
-        local ret = (v == 1e-4)
-        return ret
-    end
-}
-
 Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_mean"] = {
     nickname = "vaxd_flu_suscep_mean",
     description = "",
@@ -147,6 +135,18 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_mean"
     value = 0.5,
     validate = function(v)
         local ret = (v == 0.5)
+        return ret
+    end
+}
+
+Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_variance"] = {
+    nickname = "vaxd_flu_suscep_var",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 1e-4,
+    validate = function(v)
+        local ret = (v == 1e-4)
         return ret
     end
 }
@@ -176,18 +176,6 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_is_
     end
 }
 
-Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_variance"] = {
-    nickname = "unvaxd_flu_suscep_var",
-    description = "",
-    flag  = "const",
-    datatype = "double",
-    value = 0.0,
-    validate = function(v)
-        local ret = (v == 0.0)
-        return ret
-    end
-}
-
 Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_mean"] = {
     nickname = "unvaxd_flu_suscep_mean",
     description = "",
@@ -196,6 +184,18 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_mea
     value = 1.0,
     validate = function(v)
         local ret = (v == 1.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_variance"] = {
+    nickname = "unvaxd_flu_suscep_var",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
         return ret
     end
 }
@@ -225,18 +225,6 @@ Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_is
     end
 }
 
-Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_variance"] = {
-    nickname = "vaxd_nonflu_suscep_var",
-    description = "",
-    flag  = "const",
-    datatype = "double",
-    value = 0.0,
-    validate = function(v)
-        local ret = (v == 0.0)
-        return ret
-    end
-}
-
 Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_mean"] = {
     nickname = "vaxd_nonflu_suscep_mean",
     description = "",
@@ -245,6 +233,18 @@ Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_me
     value = 1.0,
     validate = function(v)
         local ret = (v == 1.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_variance"] = {
+    nickname = "vaxd_nonflu_suscep_var",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
         return ret
     end
 }
@@ -274,18 +274,6 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_
     end
 }
 
-Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_variance"] = {
-    nickname = "unvaxd_nonflu_suscep_var",
-    description = "",
-    flag  = "const",
-    datatype = "double",
-    value = 0.0,
-    validate = function(v)
-        local ret = (v == 0.0)
-        return ret
-    end
-}
-
 Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_mean"] = {
     nickname = "unvaxd_nonflu_suscep_mean",
     description = "",
@@ -294,6 +282,18 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_
     value = 1.0,
     validate = function(v)
         local ret = (v == 1.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_variance"] = {
+    nickname = "unvaxd_nonflu_suscep_var",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
         return ret
     end
 }

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -114,15 +114,27 @@ Parameters["parameters"]["probability_of_prior_immunity_if_unvaccinated"] = {
     end
 }
 
--- INFLUENZA SUSCEPTIBILITY PARAMETERS
-Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_shape"] = {
-    nickname = "vaxd_flu_suscep_shape",
+-- VACCINATED INFLUENZA SUSCEPTIBILITY PARAMETERS
+Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_is_continuous"] = {
+    nickname = "vaxd_flu_suscep_is_contin",
     description = "",
     flag  = "const",
     datatype = "double",
-    value = 0.0,
+    value = 1.0,
     validate = function(v)
-        local ret = (v == 0.0)
+        local ret = (v == 1.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_variance"] = {
+    nickname = "vaxd_flu_suscep_var",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 1e-4,
+    validate = function(v)
+        local ret = (v == 1e-4)
         return ret
     end
 }
@@ -132,9 +144,9 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_mean"
     description = "",
     flag  = "const",
     datatype = "double",
-    value = 1.0,
+    value = 0.5,
     validate = function(v)
-        local ret = (v == 1.0)
+        local ret = (v == 0.5)
         return ret
     end
 }
@@ -151,8 +163,21 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_baseline"] = {
     end
 }
 
-Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_shape"] = {
-    nickname = "unvaxd_flu_suscep_shape",
+-- UNVACCINATED INFLUENZA SUSCEPTIBILITY PARAMETERS
+Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_is_continuous"] = {
+    nickname = "unvaxd_flu_suscep_is_contin",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_variance"] = {
+    nickname = "unvaxd_flu_suscep_var",
     description = "",
     flag  = "const",
     datatype = "double",
@@ -187,9 +212,21 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_baseline"] = {
     end
 }
 
--- NONINFLUENZA SUSCEPTIBILITY PARAMETERS
-Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_shape"] = {
-    nickname = "vaxd_nonflu_suscep_shape",
+-- VACCINATED NONINFLUENZA SUSCEPTIBILITY PARAMETERS
+Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_is_continuous"] = {
+    nickname = "vaxd_nonflu_suscep_is_contin",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_variance"] = {
+    nickname = "vaxd_nonflu_suscep_var",
     description = "",
     flag  = "const",
     datatype = "double",
@@ -224,8 +261,21 @@ Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_baseline"] = {
     end
 }
 
-Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_shape"] = {
-    nickname = "unvaxd_nonflu_suscep_shape",
+-- UNVACCINATED NONINFLUENZA SUSCEPTIBILITY PARAMETERS
+Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_is_continuous"] = {
+    nickname = "unvaxd_nonflu_suscep_is_contin",
+    description = "",
+    flag  = "const",
+    datatype = "double",
+    value = 0.0,
+    validate = function(v)
+        local ret = (v == 0.0)
+        return ret
+    end
+}
+
+Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_variance"] = {
+    nickname = "unvaxd_nonflu_suscep_var",
     description = "",
     flag  = "const",
     datatype = "double",

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -31,6 +31,18 @@ Parameters["parameters"] = {}
 -- Parameters["parameters"]["fullname"] = {
 --     nickname = "nickname",
 --     description = "description",
+--     flag  = "step",
+--     datatype = "integer/double",
+--     values = {list of values}
+--     validate = function(v)
+--         local ret = (boolean check)
+--         return ret
+--     end
+-- }
+
+-- Parameters["parameters"]["fullname"] = {
+--     nickname = "nickname",
+--     description = "description",
 --     flag  = "copy",
 --     datatype = "integer/double",
 --     who = "fullname/nickname of param to copy from",
@@ -353,11 +365,11 @@ Parameters["parameters"]["probability_of_care_seeking_if_unvaccinated"] = {
 Parameters["parameters"]["probability_of_daily_influenza_exposure"] = {
     nickname = "pr_flu_exposure",
     description = "",
-    flag  = "const",
+    flag  = "step",
     datatype = "double",
-    value = 0.01,
+    values = {0.001, 0.005, 0.01},
     validate = function(v)
-        local ret = (v == 0.01)
+        local ret = (v >= 0.001) and (v <= 0.01)
         return ret
     end
 }

--- a/include/storyteller/parameters.hpp
+++ b/include/storyteller/parameters.hpp
@@ -122,8 +122,8 @@ class Parameters {
 
     void calc_strain_probs();
 
-    double sample_discrete_susceptibility(const bool vaccinated, const double suscep_w_prior, const double suscep_wo_prior) const;
-    double sample_continuous_susceptibility(const double shape, const double mean) const;
+    double sample_discrete_susceptibility(const bool vaccinated, const StrainType strain) const;
+    double sample_continuous_susceptibility(const bool vaccinated, const StrainType strain) const;
 
     double sample_discrete_vaccine_effect(const double b) const;
     double sample_continuous_vaccine_effect(const double a, const double b) const;

--- a/include/storyteller/parameters.hpp
+++ b/include/storyteller/parameters.hpp
@@ -125,8 +125,8 @@ class Parameters {
     double sample_discrete_susceptibility(const bool vaccinated, const StrainType strain) const;
     double sample_continuous_susceptibility(const bool vaccinated, const StrainType strain) const;
 
-    double sample_discrete_vaccine_effect(const double b) const;
-    double sample_continuous_vaccine_effect(const double a, const double b) const;
+    double sample_discrete_vaccine_effect(const StrainType strain) const;
+    double sample_continuous_vaccine_effect(const StrainType strain) const;
 
     RngHandler* rng;
     DatabaseHandler* db;

--- a/include/storyteller/utility.hpp
+++ b/include/storyteller/utility.hpp
@@ -55,6 +55,9 @@ namespace util {
      * @return vector2d<double> Vector of calculated combinations
      */
     extern vector2d<double> vec_combinations(vector2d<double> vecs);
+
+    extern double beta_a_from_mean_var(double mean, double var);
+    extern double beta_b_from_mean_var(double mean, double var);
 }
 
 /**

--- a/src/database_handler.cpp
+++ b/src/database_handler.cpp
@@ -317,21 +317,28 @@ int DatabaseHandler::init_database() {
         if (flag == "const") {
             par_values[fullname] = {p.get<double>("value")};
         } else if (flag == "step") {
-            const auto start    = p.get<double>("lower");
-            const auto end      = p.get<double>("upper");
-            const auto step     = p.get<double>("step");
-            const size_t n_vals = std::ceil(((end - start) / step) + 1);
+            auto defined_vals = p.get<sol::optional<std::vector<double>>>("values");
+            if (defined_vals) {
+                for (const double& v : defined_vals.value()) {
+                    par_values[fullname].push_back(v);
+                }
+            } else {
+                const auto start    = p.get<double>("lower");
+                const auto end      = p.get<double>("upper");
+                const auto step     = p.get<double>("step");
+                const size_t n_vals = std::ceil(((end - start) / step) + 1);
 
-            double v = start;
-            for (size_t i = 0; i < n_vals; ++i) {
-                par_values[fullname].push_back(v);
-                v += step;
-            }
+                double v = start;
+                for (size_t i = 0; i < n_vals; ++i) {
+                    par_values[fullname].push_back(v);
+                    v += step;
+                }
 
-            if (std::abs((v - step) - end) > tolerance) {
-                std::cerr << "ERROR: non-sensible step size for " << fullname << '\n';
-                std::cerr << std::abs(v - end) << " > " << tolerance << '\n';
-                exit(-1);
+                if (std::abs((v - step) - end) > tolerance) {
+                    std::cerr << "ERROR: non-sensible step size for " << fullname << '\n';
+                    std::cerr << std::abs(v - end) << " > " << tolerance << '\n';
+                    exit(-1);
+                }
             }
         } else if (flag == "copy") {
             const auto who = p.get<std::string>("who");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -51,6 +51,16 @@ namespace util {
         }
         return out;
     }
+
+    double beta_a_from_mean_var(double mean, double var) {
+        auto max_var = mean * (1 - mean);
+        return (var < max_var) ? mean * ((max_var / var) - 1.0) : -1.0;
+    }
+
+    double beta_b_from_mean_var(double mean, double var) {
+        auto max_var = mean * (1 - mean);
+        return (var < max_var) ? (1 - mean) * ((max_var / var) - 1.0) : -1.0;
+    }
 }
 
 RngHandler::RngHandler() {


### PR DESCRIPTION
Changelog:

- Susceptibility is always treated as a probability (with domain [0,1]). Thus, the continuous susceptibility sampler now samples a user-parameterized beta distribution.
- User parameter file now has more descriptive susceptibility and vaccine effect parameters
- Utility functions to calculate beta distribution parameters from mean and variance
- Step parameters can now use a list of values rather than defining a range to step through