### PR TITLE
Very basic HPC-mode

### DIFF
--- a/examples/default/tome.lua
+++ b/examples/default/tome.lua
@@ -4,6 +4,7 @@ Tome = {}
 Tome["experiment_name"] = "default"
 Tome["n_realizations"] = 1
 Tome["par_value_tolerance"] = 1e-10
+Tome["output_dir_path"] = "out"
 
 -- CONFIGURATION TABLE OF CONTENTS
 Tome["parameters"] = "config/parameters.lua"

--- a/include/storyteller/database_handler.hpp
+++ b/include/storyteller/database_handler.hpp
@@ -69,13 +69,14 @@ class DatabaseHandler {
     std::map<std::string, double> read_parameters(unsigned int serial, const std::vector<std::string>& pars);
     void write_metrics(const Ledger* ledger, const Parameters* par);
 
+    void start_job(unsigned int serial);
+    void end_job(unsigned int serial);
+
   private:
     void create_table();
     void clear_table();
 
     void read_job(unsigned int serial);
-    void start_job(unsigned int serial);
-    void end_job(unsigned int serial);
 
     void clear_metrics(unsigned int serial);
 

--- a/include/storyteller/database_handler.hpp
+++ b/include/storyteller/database_handler.hpp
@@ -72,6 +72,9 @@ class DatabaseHandler {
     void start_job(unsigned int serial);
     void end_job(unsigned int serial);
 
+    void drop_table_if_exists(std::string table);
+    void import_metrics_from(std::string file_path);
+
   private:
     void create_table();
     void clear_table();

--- a/include/storyteller/simulator.hpp
+++ b/include/storyteller/simulator.hpp
@@ -77,6 +77,8 @@ class Simulator {
      */
     void tick();
 
+    void write_metrics_csv();
+
     size_t sim_time;                        ///< Current simulation time step
     std::map<std::string, bool> sim_flags;  ///< Program flags provided by the Storyteller
 

--- a/include/storyteller/storyteller.hpp
+++ b/include/storyteller/storyteller.hpp
@@ -30,6 +30,7 @@ enum OperationType {
     INITIALIZE,
     GENERATE_SYNTHETIC_POPULATION,
     BATCH_SIM,
+    SLURP_CSVS_INTO_DATABASE,
     NUM_OPERATION_TYPES
 };
 
@@ -148,6 +149,8 @@ class Storyteller {
     void reset();
 
     int generate_synthpop();
+
+    int slurp_metrics_files();
 
     std::unique_ptr<Tome> tome;
     std::unique_ptr<Simulator> simulator;           ///< Created for each simulation to be run

--- a/scripts/slurp_metrics_into_db.R
+++ b/scripts/slurp_metrics_into_db.R
@@ -1,0 +1,28 @@
+.pkgs <- c("tidytable", "DBI", "pbapply")
+
+if (interactive()) {
+  stopifnot(all(sapply(.pkgs, require, character.only = TRUE)))
+} else {
+  suppressPackageStartupMessages(
+    stopifnot(all(sapply(.pkgs, require, character.only = TRUE)))
+  )
+}
+
+.args <- if (interactive()) c(
+  "/home/anpillai/documents/work/personal/storyteller/examples/default/default.sqlite",
+  "/home/anpillai/documents/work/personal/storyteller/examples/default/out"
+) else commandArgs(trailingOnly = TRUE)
+
+files <- list.files(.args[2], full.names = TRUE)
+
+csv_to_db <- function(file_path, db) {
+  dbWriteTable(db, "met", as.data.frame(fread(file_path)), append = TRUE)
+}
+
+pboptions(type = "timer", char = ":")
+
+con <- dbConnect(RSQLite::SQLite(), .args[1])
+dbBegin(con)
+invisible(pbapply::pbsapply(files, csv_to_db, db = con))
+dbCommit(con)
+dbDisconnect(con)

--- a/src/database_handler.cpp
+++ b/src/database_handler.cpp
@@ -135,7 +135,7 @@ void DatabaseHandler::end_job(unsigned int serial) {
             std::cerr << "job end\n";
         }
     } catch (std::exception& e) {
-        std::cerr << "Start job " << serial << " failed:" << '\n';
+        std::cerr << "End job " << serial << " failed:" << '\n';
         std::cerr << "\tSQLite exception: " << e.what() << '\n';
     }
 }
@@ -145,7 +145,7 @@ std::map<std::string, double> DatabaseHandler::read_parameters(unsigned int seri
     for (size_t i = 0; i < n_transaction_attempts; ++i) {
         ret.clear();
         try {
-            SQLite::Database db(database_path);
+            SQLite::Database db(database_path, SQLite::OPEN_READONLY);
             SQLite::Statement query(db, "SELECT * FROM par WHERE serial = ?");
             query.bind(1, serial);
             while (query.executeStep()) {

--- a/src/database_handler.cpp
+++ b/src/database_handler.cpp
@@ -144,7 +144,6 @@ std::map<std::string, double> DatabaseHandler::read_parameters(unsigned int seri
     std::map<std::string, double> ret;
     for (size_t i = 0; i < n_transaction_attempts; ++i) {
         ret.clear();
-        start_job(serial);
         try {
             SQLite::Database db(database_path);
             SQLite::Statement query(db, "SELECT * FROM par WHERE serial = ?");
@@ -222,7 +221,6 @@ void DatabaseHandler::write_metrics(const Ledger* ledger, const Parameters* par)
             } else {
                 std::cerr << "mets written... ";
             }
-            end_job((unsigned int) par->simulation_serial);
             break;
         } catch (std::exception& e) {
             std::cerr << "Write attempt " << i << " failed:" << '\n';

--- a/src/storyteller.cpp
+++ b/src/storyteller.cpp
@@ -247,9 +247,12 @@ int Storyteller::slurp_metrics_files() {
     db_handler->drop_table_if_exists("met");
 
     fs::path out_dir = tome->get_path("out_dir");
-    for (auto& met_file : fs::directory_iterator(out_dir)) {
-        db_handler->import_metrics_from(met_file.path());
-    }
+    std::stringstream cmd;
+    cmd << "Rscript " << tome->get_path("slurp.R") << ' '
+                      << tome->get_path("database") << ' '
+                      << tome->get_path("out_dir");
+    if (simulation_flags["verbose"]) std::cerr << "Calling `" << cmd.str() << "`\n";
+    return system(cmd.str().c_str());
 
     return 0;
 }

--- a/src/storyteller.cpp
+++ b/src/storyteller.cpp
@@ -175,6 +175,7 @@ int Storyteller::batch_simulation() {
             draw_simvis();
         }
 
+        db_handler->end_job(simulation_serial);
         reset();
         ++simulation_serial;
     }
@@ -189,6 +190,7 @@ int Storyteller::batch_simulation() {
  */
 void Storyteller::init_simulation() {
         db_handler = std::make_unique<DatabaseHandler>(this);
+        db_handler->start_job(simulation_serial);
         rng_handler = std::make_unique<RngHandler>();
         parameters = std::make_unique<Parameters>(rng_handler.get(), db_handler.get(), tome.get());
         parameters->read_parameters_for_serial(simulation_serial);

--- a/src/storyteller.cpp
+++ b/src/storyteller.cpp
@@ -51,6 +51,7 @@ Storyteller::Storyteller(int argc, char* argv[])
     simulation_flags["verbose"]      = cmdl_args[{"-v", "--verbose"}];
     simulation_flags["very_verbose"] = cmdl_args[{"-vv", "--very-verbose"}];
     simulation_flags["synthpop"]     = cmdl_args["gen-synth-pop"];
+    simulation_flags["hpc_mode"]     = cmdl_args["hpc"];
 
     if (simulation_flags.at("very_verbose")) simulation_flags.at("verbose") = true;
 

--- a/src/tome.cpp
+++ b/src/tome.cpp
@@ -95,6 +95,14 @@ void Tome::determine_paths() {
     paths["linelist"] = tome_root / "linelist.out";
     paths["scripts"]  = storyteller_root / "scripts";
     paths["simvis.R"] = paths.at("scripts") / "simvis.R";
+
+    bool user_defined_out_dir = element_lookup.count("output_dir_path");
+    if (user_defined_out_dir) {
+        fs::path out_dir = get_element_as<std::string>("output_dir_path");
+        out_dir = (out_dir.is_absolute()) ? out_dir : tome_root / out_dir;
+        fs::create_directories(out_dir);
+        paths["out_dir"] = out_dir;
+    }
 }
 
 bool Tome::check_for_req_items(sol::table core_tome_table) {

--- a/src/tome.cpp
+++ b/src/tome.cpp
@@ -95,6 +95,7 @@ void Tome::determine_paths() {
     paths["linelist"] = tome_root / "linelist.out";
     paths["scripts"]  = storyteller_root / "scripts";
     paths["simvis.R"] = paths.at("scripts") / "simvis.R";
+    paths["slurp.R"] = paths.at("scripts") / "slurp_metrics_into_db.R";
 
     bool user_defined_out_dir = element_lookup.count("output_dir_path");
     if (user_defined_out_dir) {

--- a/src/tome.cpp
+++ b/src/tome.cpp
@@ -85,8 +85,8 @@ void Tome::determine_paths() {
 
     bool user_defined_db_path = element_lookup.count("database_path");
     fs::path db_path = user_defined_db_path
-                   ? get_element_as<std::string>("database_path")
-                   : get_element_as<std::string>("experiment_name") + ".sqlite";
+                           ? get_element_as<std::string>("database_path")
+                           : get_element_as<std::string>("experiment_name") + ".sqlite";
 
     paths["tome_rt"]  = tome_root;
     paths["database"] = tome_root / db_path;


### PR DESCRIPTION
Changes:

- program now has `--hpc` mode that will redirect metrics to a CSV file in a user-specified directory
- program has a `--hpc --slurp` feature that loads all of the CSV files in the user-specified directory into the experiment database

These features are implemented in a very basic way but have been tested. They are likely to change in the future.