### PR TITLE
Changing beta-distributed susceptibility to normally-distributed log odds

### DIFF
--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -139,14 +139,14 @@ Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_mean"
     end
 }
 
-Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_variance"] = {
-    nickname = "vaxd_flu_suscep_var",
+Parameters["parameters"]["vaccinated_influenza_susceptibility_distribution_standard_deviation"] = {
+    nickname = "vaxd_flu_suscep_sd",
     description = "",
     flag  = "const",
     datatype = "double",
-    value = 1e-4,
+    value = 1e-1,
     validate = function(v)
-        local ret = (v == 1e-4)
+        local ret = (v == 1e-1)
         return ret
     end
 }
@@ -188,14 +188,14 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_mea
     end
 }
 
-Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_variance"] = {
-    nickname = "unvaxd_flu_suscep_var",
+Parameters["parameters"]["unvaccinated_influenza_susceptibility_distribution_standard_deviation"] = {
+    nickname = "unvaxd_flu_suscep_sd",
     description = "",
     flag  = "const",
     datatype = "double",
-    value = 0.0,
+    value = 1e-1,
     validate = function(v)
-        local ret = (v == 0.0)
+        local ret = (v == 1e-1)
         return ret
     end
 }
@@ -237,8 +237,8 @@ Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_me
     end
 }
 
-Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_variance"] = {
-    nickname = "vaxd_nonflu_suscep_var",
+Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_standard_deviation"] = {
+    nickname = "vaxd_nonflu_suscep_sd",
     description = "",
     flag  = "const",
     datatype = "double",
@@ -286,8 +286,8 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_
     end
 }
 
-Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_variance"] = {
-    nickname = "unvaxd_nonflu_suscep_var",
+Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_distribution_standard_deviation"] = {
+    nickname = "unvaxd_nonflu_suscep_sd",
     description = "",
     flag  = "const",
     datatype = "double",

--- a/include/storyteller/utility.hpp
+++ b/include/storyteller/utility.hpp
@@ -58,6 +58,9 @@ namespace util {
 
     extern double beta_a_from_mean_var(double mean, double var);
     extern double beta_b_from_mean_var(double mean, double var);
+
+    extern double logistic(const double log_odds);
+    extern double logit(const double prob);
 }
 
 /**

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -7,6 +7,7 @@
  * @copyright TBD
  */
 #include <algorithm>
+#include <cmath>
 
 
 #include <storyteller/utility.hpp>
@@ -60,6 +61,14 @@ namespace util {
     double beta_b_from_mean_var(double mean, double var) {
         auto max_var = mean * (1 - mean);
         return (var < max_var) ? (1 - mean) * ((max_var / var) - 1.0) : -1.0;
+    }
+
+    double logistic(const double log_odds) {
+      return 1 / (1 + std::exp(-1.0 * log_odds));
+    }
+
+    double logit(const double prob) {
+      return std::log(prob / (1 - prob));
     }
 }
 


### PR DESCRIPTION
This makes the parameterization more intuitive (mean and sd of the log odds of susceptibility).