### PR TITLE
Daily strain sampling optimization

### DIFF
--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -70,7 +70,7 @@ Parameters["parameters"]["population_size"] = {
     description = "",
     flag  = "const",
     datatype = "integer",
-    value = 1e3,
+    value = 1e5,
     validate = function(v)
         local ret = (v > 0)
         return ret

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -70,7 +70,7 @@ Parameters["parameters"]["population_size"] = {
     description = "",
     flag  = "const",
     datatype = "integer",
-    value = 1e5,
+    value = 1e3,
     validate = function(v)
         local ret = (v > 0)
         return ret

--- a/examples/default/tome.lua
+++ b/examples/default/tome.lua
@@ -2,7 +2,6 @@ Tome = {}
 
 -- GENERIC STORYTELLER PARAMETERS
 Tome["experiment_name"] = "default"
-Tome["database_path"] = "baseline_performance.sqlite"
 Tome["n_realizations"] = 10
 Tome["par_value_tolerance"] = 1e-10
 Tome["output_dir_path"] = "out"

--- a/examples/default/tome.lua
+++ b/examples/default/tome.lua
@@ -2,7 +2,8 @@ Tome = {}
 
 -- GENERIC STORYTELLER PARAMETERS
 Tome["experiment_name"] = "default"
-Tome["n_realizations"] = 1
+Tome["database_path"] = "baseline_performance.sqlite"
+Tome["n_realizations"] = 10
 Tome["par_value_tolerance"] = 1e-10
 Tome["output_dir_path"] = "out"
 

--- a/include/storyteller/parameters.hpp
+++ b/include/storyteller/parameters.hpp
@@ -98,6 +98,7 @@ class Parameters {
     std::vector<double> sample_susceptibility(const Person* p) const;
     std::vector<double> sample_vaccine_effect() const;
     StrainType sample_strain() const;
+    std::vector<StrainType> daily_strain_sample() const;
 
     bool are_valid() const;
 

--- a/src/community.cpp
+++ b/src/community.cpp
@@ -40,14 +40,25 @@ void Community::init_population() {
 }
 
 void Community::transmission(size_t time) {
+    auto strain_sample = par->daily_strain_sample();
     for (auto& p : people) {
-        // determine if exposure with occurs
-        auto strain = par->sample_strain();
+        auto strain = strain_sample.back();
+        strain_sample.pop_back();
+
         if (strain == NUM_STRAIN_TYPES) continue;
         // determine if infection occurs
         auto infection_occurs = p->attempt_infection(strain, time);
         if (infection_occurs) ledger->log_infection(infection_occurs);
     }
+
+    // for (auto& p : people) {
+    //     // determine if exposure with occurs
+    //     auto strain = par->sample_strain();
+    //     if (strain == NUM_STRAIN_TYPES) continue;
+    //     // determine if infection occurs
+    //     auto infection_occurs = p->attempt_infection(strain, time);
+    //     if (infection_occurs) ledger->log_infection(infection_occurs);
+    // }
 }
 
 void Community::vaccinate_population(size_t time) {

--- a/src/community.cpp
+++ b/src/community.cpp
@@ -51,6 +51,7 @@ void Community::transmission(size_t time) {
         if (infection_occurs) ledger->log_infection(infection_occurs);
     }
 
+    // old method that samples a single strain per person (keeping for reference)
     // for (auto& p : people) {
     //     // determine if exposure with occurs
     //     auto strain = par->sample_strain();


### PR DESCRIPTION
New sampling method samples a collection of strains for the population each day and then shuffles it.

This method seems to improve performance by 2+ times (dep on hardware and pop size).