### PR TITLE
Implementing time-varying model components

### DIFF
--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -241,7 +241,8 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_baseline"] = {
 -- INFLUENZA INFECTION PARAMETERS
 Parameters["parameters"]["influenza_infection_refactory_period_length"] = {
   nickname = "flu_inf_refact_len",
-  description = "",
+  description = [[The number of days after an influenza infection during which
+  the individual cannot be infected by any other pathogen.]],
   flag  = "const",
   datatype = "integer",
   value = 0,
@@ -253,7 +254,11 @@ Parameters["parameters"]["influenza_infection_refactory_period_length"] = {
 
 Parameters["parameters"]["influenza_infection_generates_immunity"] = {
   nickname = "flu_inf_gen_immunity",
-  description = "",
+  description = [[This boolean flag controls whether influenza infections generate
+  immunity. If immunity is generated (1), after the refactory period, immune
+  protection is set to 1 (or susceptibility = 0) conferring complete protection.
+  If immunity is not generated (0), after the refactory period, susceptibility
+  remains equal to its prior value for that individual.]],
   flag  = "const",
   datatype = "integer",
   value = 1,
@@ -265,7 +270,9 @@ Parameters["parameters"]["influenza_infection_generates_immunity"] = {
 
 Parameters["parameters"]["influenza_infection_immunity_wanes"] = {
   nickname = "flu_inf_immunity_wanes",
-  description = "",
+  description = [[This boolean flag controls whether influenza-infection-derived
+  immunity wanes over time after the refactory period (1) or is constant over time
+  (0).]],
   flag  = "const",
   datatype = "integer",
   value = 0,
@@ -277,7 +284,8 @@ Parameters["parameters"]["influenza_infection_immunity_wanes"] = {
 
 Parameters["parameters"]["influenza_infection_immunity_half_life"] = {
   nickname = "flu_inf_immunity_half_life",
-  description = "",
+  description = [[If influenza-infection-derived immunity wanes over time, the waning
+  rate will be derived to produce this specified half-life.]],
   flag  = "const",
   datatype = "integer",
   value = 1500,
@@ -405,9 +413,10 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_baseline"] = 
 }
 
 -- NONINFLUENZA INFECTION PARAMETERS
-Parameters["parameters"]["influenza_noninfection_refactory_period_length"] = {
+Parameters["parameters"]["noninfluenza_infection_refactory_period_length"] = {
   nickname = "nonflu_inf_refact_len",
-  description = "",
+  description = [[The number of days after a noninfluenza infection during which
+  the individual cannot be infected by any other pathogen.]],
   flag  = "copy",
   datatype = "integer",
   who = "flu_inf_refact_len",
@@ -419,7 +428,11 @@ Parameters["parameters"]["influenza_noninfection_refactory_period_length"] = {
 
 Parameters["parameters"]["noninfluenza_infection_generates_immunity"] = {
   nickname = "nonflu_inf_gen_immunity",
-  description = "",
+  description = [[This boolean flag controls whether noninfluenza infections generate
+  immunity. If immunity is generated (1), after the refactory period, immune
+  protection is set to 1 (or susceptibility = 0) conferring complete protection.
+  If immunity is not generated (0), after the refactory period, susceptibility
+  remains equal to its prior value for that individual.]],
   flag  = "const",
   datatype = "integer",
   value = 0,
@@ -431,7 +444,9 @@ Parameters["parameters"]["noninfluenza_infection_generates_immunity"] = {
 
 Parameters["parameters"]["noninfluenza_infection_immunity_wanes"] = {
   nickname = "nonflu_inf_immunity_wanes",
-  description = "",
+  description = [[This boolean flag controls whether noninfluenza-infection-derived
+  immunity wanes over time after the refactory period (1) or is constant over time
+  (0).]],
   flag  = "const",
   datatype = "integer",
   value = 0,
@@ -443,7 +458,8 @@ Parameters["parameters"]["noninfluenza_infection_immunity_wanes"] = {
 
 Parameters["parameters"]["noninfluenza_infection_immunity_half_life"] = {
   nickname = "nonflu_inf_immunity_half_life",
-  description = "",
+  description = [[If noninfluenza-infection-derived immunity wanes over time, the
+  waning rate will be derived to produce this specified half-life.]],
   flag  = "const",
   datatype = "integer",
   value = 14,
@@ -500,19 +516,22 @@ Parameters["parameters"]["influenza_vaccine_effect_distribution_variance"] = {
 
 Parameters["parameters"]["influenza_vaccine_waning_protection"] = {
   nickname = "flu_vax_effect_wanes",
-  description = "",
+  description = [[This boolean flag controls whether vaccine efficacy against
+  influenza infection wanes over time after the refactory period (1) or is constant
+  over time (0).]],
   flag  = "const",
   datatype = "double",
   value = 0.0,
   validate = function(v)
-      local ret = (v == 0.0) or (v == 1.0)
+      local ret = (v == 0) or (v == 1)
       return ret
   end
 }
 
 Parameters["parameters"]["influenza_vaccine_half_life"] = {
   nickname = "flu_vax_effect_half_life",
-  description = "",
+  description = [[If vaccine efficacy against influenza infection wanes over time,
+  the waning rate will be derived to produce this specified half-life.]],
   flag  = "const",
   datatype = "double",
   value = 200,
@@ -646,36 +665,40 @@ Parameters["parameters"]["probability_of_daily_noninfluenza_exposure"] = {
 -- SEASONAL FORCING PARAMETERS
 Parameters["parameters"]["seasonal_forcing_amplitude_multiplier"] = {
   nickname = "seasonal_amplitude_mult",
-  description = "",
+  description = [[This controls how much seasonal forcing is applied to the daily
+  exposure probabilities. If it is set to 0, no seasonal forcing is applied and
+  daily exposure probabilities are constant over time.]],
   flag  = "const",
   datatype = "double",
   value = 0.0,
   validate = function(v)
-      local ret = (v == 0.0)
+      local ret = (v >= 0)
       return ret
   end
 }
 
 Parameters["parameters"]["seasonal_forcing_period"] = {
   nickname = "seasonal_period",
-  description = "",
+  description = [[If daily exposure probabilities seasonally vary over time, this
+  controls the period of the seasonal cycling.]],
   flag  = "const",
   datatype = "integer",
   value = 200,
   validate = function(v)
-      local ret = (v == 200)
+      local ret = (v > 0)
       return ret
   end
 }
 
 Parameters["parameters"]["seasonal_forcing_phase_shift"] = {
   nickname = "seasonal_shift",
-  description = "",
+  description = [[If daily exposure probabilities seasonally vary over time, this
+  controls the phase shift of the seasonal cycling.]],
   flag  = "const",
   datatype = "integer",
   value = 100,
   validate = function(v)
-      local ret = (v == 100)
+      local ret = (v >= 0)
       return ret
   end
 }

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -541,6 +541,20 @@ Parameters["parameters"]["influenza_vaccine_half_life"] = {
   end
 }
 
+Parameters["parameters"]["influenza_vaccine_lag_time_until_waning"] = {
+  nickname = "flu_vax_effect_lag_til_waning",
+  description = [[If vaccine efficacy against influenza infection wanes over time,
+  this controls the lag time between when vaccination occurs and when efficacy
+  waning begins.]],
+  flag  = "const",
+  datatype = "double",
+  value = 0,
+  validate = function(v)
+      local ret = (v >= 0)
+      return ret
+  end
+}
+
 -- NONINFLUENZA VACCINE PARAMETERS
 Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_is_continuous"] = {
     nickname = "nonflu_vax_effect_is_contin",
@@ -607,6 +621,20 @@ Parameters["parameters"]["noninfluenza_vaccine_half_life"] = {
   value = 14,
   validate = function(v)
       local ret = (v > 0)
+      return ret
+  end
+}
+
+Parameters["parameters"]["noninfluenza_vaccine_lag_time_until_waning"] = {
+  nickname = "nonflu_vax_effect_lag_til_waning",
+  description = [[If vaccine efficacy against noninfluenza infection wanes over time,
+  this controls the lag time between when vaccination occurs and when efficacy
+  waning begins.]],
+  flag  = "const",
+  datatype = "double",
+  value = 0,
+  validate = function(v)
+      local ret = (v >= 0)
       return ret
   end
 }

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -349,6 +349,30 @@ Parameters["parameters"]["influenza_vaccine_effect_distribution_variance"] = {
     end
 }
 
+Parameters["parameters"]["influenza_vaccine_waning_protection"] = {
+  nickname = "flu_vax_effect_wanes",
+  description = "",
+  flag  = "const",
+  datatype = "double",
+  value = 0.0,
+  validate = function(v)
+      local ret = (v == 0.0) or (v == 1.0)
+      return ret
+  end
+}
+
+Parameters["parameters"]["influenza_vaccine_half_life"] = {
+  nickname = "flu_vax_effect_half_life",
+  description = "",
+  flag  = "const",
+  datatype = "double",
+  value = 200,
+  validate = function(v)
+      local ret = (v > 0)
+      return ret
+  end
+}
+
 -- NONINFLUENZA VACCINE PARAMETERS
 Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_is_continuous"] = {
     nickname = "nonflu_vax_effect_is_contin",

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -459,3 +459,40 @@ Parameters["parameters"]["probability_of_daily_noninfluenza_exposure"] = {
         return ret
     end
 }
+
+-- SEASONAL FORCING PARAMETERS
+Parameters["parameters"]["seasonal_forcing_amplitude_multiplier"] = {
+  nickname = "seasonal_amplitude_mult",
+  description = "",
+  flag  = "const",
+  datatype = "double",
+  value = 0.0,
+  validate = function(v)
+      local ret = (v == 0.0)
+      return ret
+  end
+}
+
+Parameters["parameters"]["seasonal_forcing_period"] = {
+  nickname = "seasonal_period",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 200,
+  validate = function(v)
+      local ret = (v == 200)
+      return ret
+  end
+}
+
+Parameters["parameters"]["seasonal_forcing_phase_shift"] = {
+  nickname = "seasonal_shift",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 100,
+  validate = function(v)
+      local ret = (v == 100)
+      return ret
+  end
+}

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -584,6 +584,33 @@ Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_variance"] = 
     end
 }
 
+Parameters["parameters"]["noninfluenza_vaccine_waning_protection"] = {
+  nickname = "nonflu_vax_effect_wanes",
+  description = [[This boolean flag controls whether vaccine efficacy against
+  noninfluenza infection wanes over time after the refactory period (1) or is constant
+  over time (0).]],
+  flag  = "const",
+  datatype = "double",
+  value = 0.0,
+  validate = function(v)
+      local ret = (v == 0) or (v == 1)
+      return ret
+  end
+}
+
+Parameters["parameters"]["noninfluenza_vaccine_half_life"] = {
+  nickname = "nonflu_vax_effect_half_life",
+  description = [[If vaccine efficacy against noninfluenza infection wanes over time,
+  the waning rate will be derived to produce this specified half-life.]],
+  flag  = "const",
+  datatype = "double",
+  value = 14,
+  validate = function(v)
+      local ret = (v > 0)
+      return ret
+  end
+}
+
 -- INFECTION OUTCOME PARAMETERS
 Parameters["parameters"]["probability_of_symptoms_if_influenza"] = {
     nickname = "pr_sympt_flu",

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -239,8 +239,8 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_baseline"] = {
 }
 
 -- INFLUENZA INFECTION PARAMETERS
-Parameters["parameters"]["influenza_infection_refactory_period_length"] = {
-  nickname = "flu_inf_refact_len",
+Parameters["parameters"]["influenza_infection_refractory_period_length"] = {
+  nickname = "flu_inf_refract_len",
   description = [[The number of days after an influenza infection during which
   the individual cannot be infected by any other pathogen.]],
   flag  = "const",
@@ -255,9 +255,9 @@ Parameters["parameters"]["influenza_infection_refactory_period_length"] = {
 Parameters["parameters"]["influenza_infection_generates_immunity"] = {
   nickname = "flu_inf_gen_immunity",
   description = [[This boolean flag controls whether influenza infections generate
-  immunity. If immunity is generated (1), after the refactory period, immune
+  immunity. If immunity is generated (1), after the refractory period, immune
   protection is set to 1 (or susceptibility = 0) conferring complete protection.
-  If immunity is not generated (0), after the refactory period, susceptibility
+  If immunity is not generated (0), after the refractory period, susceptibility
   remains equal to its prior value for that individual.]],
   flag  = "const",
   datatype = "integer",
@@ -271,7 +271,7 @@ Parameters["parameters"]["influenza_infection_generates_immunity"] = {
 Parameters["parameters"]["influenza_infection_immunity_wanes"] = {
   nickname = "flu_inf_immunity_wanes",
   description = [[This boolean flag controls whether influenza-infection-derived
-  immunity wanes over time after the refactory period (1) or is constant over time
+  immunity wanes over time after the refractory period (1) or is constant over time
   (0).]],
   flag  = "const",
   datatype = "integer",
@@ -413,13 +413,13 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_baseline"] = 
 }
 
 -- NONINFLUENZA INFECTION PARAMETERS
-Parameters["parameters"]["noninfluenza_infection_refactory_period_length"] = {
-  nickname = "nonflu_inf_refact_len",
+Parameters["parameters"]["noninfluenza_infection_refractory_period_length"] = {
+  nickname = "nonflu_inf_refract_len",
   description = [[The number of days after a noninfluenza infection during which
   the individual cannot be infected by any other pathogen.]],
   flag  = "copy",
   datatype = "integer",
-  who = "flu_inf_refact_len",
+  who = "flu_inf_refract_len",
   validate = function(v)
       local ret = (v >= 0)
       return ret
@@ -429,9 +429,9 @@ Parameters["parameters"]["noninfluenza_infection_refactory_period_length"] = {
 Parameters["parameters"]["noninfluenza_infection_generates_immunity"] = {
   nickname = "nonflu_inf_gen_immunity",
   description = [[This boolean flag controls whether noninfluenza infections generate
-  immunity. If immunity is generated (1), after the refactory period, immune
+  immunity. If immunity is generated (1), after the refractory period, immune
   protection is set to 1 (or susceptibility = 0) conferring complete protection.
-  If immunity is not generated (0), after the refactory period, susceptibility
+  If immunity is not generated (0), after the refractory period, susceptibility
   remains equal to its prior value for that individual.]],
   flag  = "const",
   datatype = "integer",
@@ -445,7 +445,7 @@ Parameters["parameters"]["noninfluenza_infection_generates_immunity"] = {
 Parameters["parameters"]["noninfluenza_infection_immunity_wanes"] = {
   nickname = "nonflu_inf_immunity_wanes",
   description = [[This boolean flag controls whether noninfluenza-infection-derived
-  immunity wanes over time after the refactory period (1) or is constant over time
+  immunity wanes over time after the refractory period (1) or is constant over time
   (0).]],
   flag  = "const",
   datatype = "integer",
@@ -517,7 +517,7 @@ Parameters["parameters"]["influenza_vaccine_effect_distribution_variance"] = {
 Parameters["parameters"]["influenza_vaccine_waning_protection"] = {
   nickname = "flu_vax_effect_wanes",
   description = [[This boolean flag controls whether vaccine efficacy against
-  influenza infection wanes over time after the refactory period (1) or is constant
+  influenza infection wanes over time after the refractory period (1) or is constant
   over time (0).]],
   flag  = "const",
   datatype = "double",
@@ -587,7 +587,7 @@ Parameters["parameters"]["noninfluenza_vaccine_effect_distribution_variance"] = 
 Parameters["parameters"]["noninfluenza_vaccine_waning_protection"] = {
   nickname = "nonflu_vax_effect_wanes",
   description = [[This boolean flag controls whether vaccine efficacy against
-  noninfluenza infection wanes over time after the refactory period (1) or is constant
+  noninfluenza infection wanes over time after the refractory period (1) or is constant
   over time (0).]],
   flag  = "const",
   datatype = "double",

--- a/examples/default/config/parameters.lua
+++ b/examples/default/config/parameters.lua
@@ -70,7 +70,7 @@ Parameters["parameters"]["population_size"] = {
     description = "",
     flag  = "const",
     datatype = "integer",
-    value = 1e3,
+    value = 1e4,
     validate = function(v)
         local ret = (v > 0)
         return ret
@@ -212,6 +212,56 @@ Parameters["parameters"]["unvaccinated_influenza_susceptibility_baseline"] = {
     end
 }
 
+-- INFLUENZA INFECTION PARAMETERS
+Parameters["parameters"]["influenza_infection_refactory_period_length"] = {
+  nickname = "flu_inf_refact_len",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 0,
+  validate = function(v)
+      local ret = (v >= 0)
+      return ret
+  end
+}
+
+Parameters["parameters"]["influenza_infection_generates_immunity"] = {
+  nickname = "flu_inf_gen_immunity",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 1,
+  validate = function(v)
+      local ret = (v == 0) or (v == 1)
+      return ret
+  end
+}
+
+Parameters["parameters"]["influenza_infection_immunity_wanes"] = {
+  nickname = "flu_inf_immunity_wanes",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 0,
+  validate = function(v)
+      local ret = (v == 0) or (v == 1)
+      return ret
+  end
+}
+
+Parameters["parameters"]["influenza_infection_immunity_half_life"] = {
+  nickname = "flu_inf_immunity_half_life",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 1500,
+  values = {15, 1500},
+  validate = function(v)
+      local ret = (v > 0)
+      return ret
+  end
+}
+
 -- VACCINATED NONINFLUENZA SUSCEPTIBILITY PARAMETERS
 Parameters["parameters"]["vaccinated_noninfluenza_susceptibility_distribution_is_continuous"] = {
     nickname = "vaxd_nonflu_suscep_is_contin",
@@ -308,6 +358,55 @@ Parameters["parameters"]["unvaccinated_noninfluenza_susceptibility_baseline"] = 
         local ret = (v == 1.0)
         return ret
     end
+}
+
+-- NONINFLUENZA INFECTION PARAMETERS
+Parameters["parameters"]["influenza_noninfection_refactory_period_length"] = {
+  nickname = "nonflu_inf_refact_len",
+  description = "",
+  flag  = "copy",
+  datatype = "integer",
+  who = "flu_inf_refact_len",
+  validate = function(v)
+      local ret = (v >= 0)
+      return ret
+  end
+}
+
+Parameters["parameters"]["noninfluenza_infection_generates_immunity"] = {
+  nickname = "nonflu_inf_gen_immunity",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 0,
+  validate = function(v)
+      local ret = (v == 0) or (v == 1)
+      return ret
+  end
+}
+
+Parameters["parameters"]["noninfluenza_infection_immunity_wanes"] = {
+  nickname = "nonflu_inf_immunity_wanes",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 0,
+  validate = function(v)
+      local ret = (v == 0) or (v == 1)
+      return ret
+  end
+}
+
+Parameters["parameters"]["noninfluenza_infection_immunity_half_life"] = {
+  nickname = "nonflu_inf_immunity_half_life",
+  description = "",
+  flag  = "const",
+  datatype = "integer",
+  value = 14,
+  validate = function(v)
+      local ret = (v > 0)
+      return ret
+  end
 }
 
 -- INFLUENZA VACCINE PARAMETERS

--- a/include/storyteller/parameters.hpp
+++ b/include/storyteller/parameters.hpp
@@ -98,14 +98,14 @@ class Parameters {
 
     std::vector<double> sample_susceptibility(const Person* p) const;
     std::vector<double> sample_vaccine_effect() const;
-    StrainType sample_strain() const;
-    std::vector<StrainType> daily_strain_sample() const;
+    StrainType sample_strain(const size_t time) const;
+    std::vector<StrainType> daily_strain_sample(const size_t time) const;
 
     bool are_valid() const;
 
     // void update_time_varying_parameters();
 
-    std::vector<double> strain_probs;
+    std::vector<std::vector<double>> strain_probs; //[time][strain]
 
     std::string linelist_file_path;
     std::string simvis_file_path;

--- a/include/storyteller/person.hpp
+++ b/include/storyteller/person.hpp
@@ -53,6 +53,7 @@ class Person {
     void set_susceptibility(StrainType strain, double s);
 
     double get_vaccine_protection(StrainType strain) const;
+    double get_remaining_vaccine_protection(StrainType strain, size_t time) const;
     void set_vaccine_protection(StrainType strain, double vp);
 
     const std::vector<std::unique_ptr<Infection>>& get_infection_history() const;

--- a/include/storyteller/person.hpp
+++ b/include/storyteller/person.hpp
@@ -60,7 +60,7 @@ class Person {
     const std::vector<std::unique_ptr<Infection>>& get_infection_history() const;
 
     Infection* attempt_infection(StrainType strain, size_t time);
-    bool vaccinate();
+    bool vaccinate(size_t time);
 
     bool has_been_infected() const;
     bool has_been_infected_with(StrainType strain) const;
@@ -82,6 +82,7 @@ class Person {
     std::vector<double> vaccine_protection;
     std::vector<std::unique_ptr<Infection>> infection_history;
     VaccinationStatus vaccination_status;
+    size_t vaccination_time;
     const Parameters* par;
     const RngHandler* rng;
 };

--- a/include/storyteller/person.hpp
+++ b/include/storyteller/person.hpp
@@ -50,6 +50,7 @@ class Person {
     size_t get_id() const;
 
     double get_susceptibility(StrainType strain) const;
+    double get_current_susceptibility(StrainType strain, size_t time) const;
     void set_susceptibility(StrainType strain, double s);
 
     double get_vaccine_protection(StrainType strain) const;
@@ -64,9 +65,12 @@ class Person {
     bool has_been_infected() const;
     bool has_been_infected_with(StrainType strain) const;
     bool is_vaccinated() const;
-    bool is_susceptible_to(StrainType strain) const;
+    bool is_susceptible_to(StrainType strain, size_t time) const;
 
     Infection* most_recent_infection() const;
+    Infection* most_recent_infection(StrainType strain) const;
+    size_t last_infection_time() const;
+    size_t last_infection_strain() const;
 
     friend std::ostream& operator<<(std::ostream& o , const Person& p);
 

--- a/include/storyteller/utility.hpp
+++ b/include/storyteller/utility.hpp
@@ -62,6 +62,9 @@ namespace util {
 
     extern double logistic(const double log_odds);
     extern double logit(const double prob);
+
+    extern double exp_decay_rate_from_half_life(const double half_life);
+    extern double exp_decay(const double rate, const double time);
 }
 
 /**

--- a/include/storyteller/utility.hpp
+++ b/include/storyteller/utility.hpp
@@ -18,6 +18,7 @@
 namespace constants {
     extern unsigned int ZERO;
     extern unsigned int ONE;
+    extern double PI;
 }
 
 /**

--- a/scripts/simvis.R
+++ b/scripts/simvis.R
@@ -105,6 +105,15 @@ tnd_ve <- ggplot(sim_dat) +
   shared_attrs +
   theme(legend.position = "none")
 
+pr_exposure <- ggplot(sim_dat) +
+  aes(x = time) +
+  geom_line(aes(y = pr_flu_exposure, linetype = "flu")) +
+  geom_line(aes(y = pr_nonflu_exposure, linetype = "nonflu")) +
+  labs(x = "time", y = "Pr(exposure)") +
+  ylim(0, NA) +
+  shared_attrs +
+  theme(legend.position = "none")
+
 pop <- ggplot(pop_dt) +
   aes(x = value, fill = factor(vax_status)) +
   geom_histogram(bins = 50, position = "identity", alpha = 0.5) +
@@ -124,13 +133,15 @@ dash_left <- plot_grid(
   inf_by_strain,
   flu_inf_by_vax,
   mai_by_strain_vax,
-  tnd_ve
+  tnd_ve,
+  pr_exposure
 )
 
 dash <- plot_grid(
   dash_left,
   pop,
-  nrow = 1
+  nrow = 1,
+  rel_widths = c(2, 1)
 )
 
 dir.create(fig_path, showWarnings = FALSE)
@@ -139,8 +150,8 @@ ggsave(
   here(fig_path, "simvis.png"),
   dash,
   bg = "white",
-  height = 1200,
-  width = 2400,
-  units = "px",
-  dpi = 200
+  height = 9,
+  width = 16,
+  units = "in",
+  dpi = 150
 )

--- a/src/community.cpp
+++ b/src/community.cpp
@@ -40,7 +40,7 @@ void Community::init_population() {
 }
 
 void Community::transmission(size_t time) {
-    auto strain_sample = par->daily_strain_sample();
+    auto strain_sample = par->daily_strain_sample(time);
     for (auto& p : people) {
         auto strain = strain_sample.back();
         strain_sample.pop_back();
@@ -54,7 +54,7 @@ void Community::transmission(size_t time) {
     // old method that samples a single strain per person (keeping for reference)
     // for (auto& p : people) {
     //     // determine if exposure with occurs
-    //     auto strain = par->sample_strain();
+    //     auto strain = par->sample_strain(time);
     //     if (strain == NUM_STRAIN_TYPES) continue;
     //     // determine if infection occurs
     //     auto infection_occurs = p->attempt_infection(strain, time);

--- a/src/community.cpp
+++ b/src/community.cpp
@@ -67,7 +67,7 @@ void Community::vaccinate_population(size_t time) {
     if (pr_vaccination == 0) { return; }
     for (auto& p : people) {
         if (rng->draw_from_rng(VACCINATION) < pr_vaccination) {
-            p->vaccinate();
+            p->vaccinate(time);
             ledger->vax_incidence[time]++;
         }
     }

--- a/src/ledger.cpp
+++ b/src/ledger.cpp
@@ -31,7 +31,7 @@ Ledger::Ledger(const Parameters* parameters) {
     vax_incidence = std::vector<size_t>(sim_duration, 0);
 
     linelist_header = "inf_id,inf_time,inf_strain,inf_sympts,inf_care,p_id,vax_status,baseline_suscep,vax_effect";
-    simvis_header = "time,vaxd_flu_infs,vaxd_flu_mais,vaxd_nonflu_infs,vaxd_nonflu_mais,unvaxd_flu_infs,unvaxd_flu_mais,unvaxd_nonflu_infs,unvaxd_nonflu_mais,tnd_ve_est";
+    simvis_header = "time,pr_flu_exposure,pr_nonflu_exposure,vaxd_flu_infs,vaxd_flu_mais,vaxd_nonflu_infs,vaxd_nonflu_mais,unvaxd_flu_infs,unvaxd_flu_mais,unvaxd_nonflu_infs,unvaxd_nonflu_mais,tnd_ve_est";
 }
 
 Ledger::~Ledger() {}
@@ -142,6 +142,8 @@ void Ledger::generate_simvis_csv(std::string filepath) {
     file << simvis_header << '\n';
     for (size_t t = 0; t < par->get("sim_duration"); ++t) {
         file << t << ','
+             << par->strain_probs[t][INFLUENZA] << ','
+             << par->strain_probs[t][NON_INFLUENZA] << ','
              << inf_incidence[VACCINATED][INFLUENZA][t] << ','
              << mai_incidence[VACCINATED][INFLUENZA][t] << ','
              << inf_incidence[VACCINATED][NON_INFLUENZA][t] << ','

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -102,7 +102,8 @@ double Person::get_remaining_vaccine_protection(StrainType strain, size_t time) 
         const auto half_life = (strain == INFLUENZA)
                                    ? par->get("flu_vax_effect_half_life")
                                    : par->get("nonflu_vax_effect_half_life");
-        const auto waning_rate = util::exp_decay_rate_from_half_life(half_life);
+        const auto waning_rate    = util::exp_decay_rate_from_half_life(half_life);
+        const auto time_since_vax = time - vaccination_time;
         return vaccine_protection[strain] * util::exp_decay(waning_rate, time);
     } else {
         return vaccine_protection[strain];

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -38,6 +38,7 @@ Person::Person(size_t assigned_id, const Parameters* parameters, const RngHandle
     rng = rng_handler;
 
     vaccination_status = UNVACCINATED;
+    vaccination_time   = par->get("sim_duration") + 1;
     vaccine_protection = std::vector<double>(NUM_STRAIN_TYPES, 0.0);
 
     susceptibility = par->sample_susceptibility(this);
@@ -134,11 +135,12 @@ Infection* Person::attempt_infection(StrainType strain, size_t time) {
     return inf;
 }
 
-bool Person::vaccinate() {
+bool Person::vaccinate(size_t time) {
     if (vaccination_status == VACCINATED) { return false; }
     vaccination_status = VACCINATED;
+    vaccination_time   = time;
     vaccine_protection = par->sample_vaccine_effect();
-    susceptibility = par->sample_susceptibility(this);
+    susceptibility     = par->sample_susceptibility(this);
     return true;
 }
 

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -68,14 +68,14 @@ double Person::get_current_susceptibility(StrainType strain, size_t time) const 
 
             const auto waning_rate = util::exp_decay_rate_from_half_life(half_life);
 
-            const auto refactory_period = (strain == INFLUENZA)
-                                              ? par->get("flu_inf_refact_len")
-                                              : par->get("nonflu_inf_refact_len");
+            const auto refractory_period = (strain == INFLUENZA)
+                                              ? par->get("flu_inf_refract_len")
+                                              : par->get("nonflu_inf_refract_len");
 
-            // this starts waning only after the refactory period length
-            // during the refactory period, suscep will be negative though this
-            // wont matter because is_susceptible_to() is false during the refactory period
-            const auto time_since_last_inf = time - (most_recent_infection(strain)->get_infection_time() + refactory_period);
+            // this starts waning only after the refractory period length
+            // during the refractory period, suscep will be negative though this
+            // wont matter because is_susceptible_to() is false during the refractory period
+            const auto time_since_last_inf = time - (most_recent_infection(strain)->get_infection_time() + refractory_period);
 
             // 1 - exp flips the decay and will allow suscep to rise from zero to its original value
             return susceptibility[strain] * (1 - util::exp_decay(waning_rate, time_since_last_inf));
@@ -158,19 +158,19 @@ bool Person::has_been_infected_with(StrainType strain) const {
 bool Person::is_vaccinated() const { return vaccination_status == VACCINATED; }
 
 bool Person::is_susceptible_to(StrainType strain, size_t time) const {
-    // if within any infection refactory period, return false
+    // if within any infection refractory period, return false
     const auto last_inf = most_recent_infection();
     if (last_inf != nullptr) {
         const auto time_since_last_inf = time - last_inf->get_infection_time();
 
-        double refactory_period = 0;
+        double refractory_period = 0;
         switch (last_inf->get_strain()) {
-            case INFLUENZA: { refactory_period = par->get("flu_inf_refact_len"); break; }
-            case NON_INFLUENZA: { refactory_period = par->get("nonflu_inf_refact_len"); break; }
+            case INFLUENZA: { refractory_period = par->get("flu_inf_refract_len"); break; }
+            case NON_INFLUENZA: { refractory_period = par->get("nonflu_inf_refract_len"); break; }
             default: { break; }
         }
 
-        if (time_since_last_inf < refactory_period) { return false; }
+        if (time_since_last_inf < refractory_period) { return false; }
     }
 
     // if current suscep <= 0, return false

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -93,8 +93,15 @@ double Person::get_vaccine_protection(StrainType strain) const { return vaccine_
 void Person::set_vaccine_protection(StrainType strain, double vp) { vaccine_protection[strain] = vp; }
 
 double Person::get_remaining_vaccine_protection(StrainType strain, size_t time) const {
-    if (par->get("flu_vax_effect_wanes")) {
-        const auto waning_rate = util::exp_decay_rate_from_half_life(par->get("flu_vax_effect_half_life"));
+    const bool efficacy_wanes = (strain == INFLUENZA)
+                                    ? par->get("flu_vax_effect_wanes")
+                                    : par->get("nonflu_vax_effect_wanes");
+
+    if (efficacy_wanes) {
+        const auto half_life = (strain == INFLUENZA)
+                                   ? par->get("flu_vax_effect_half_life")
+                                   : par->get("nonflu_vax_effect_half_life");
+        const auto waning_rate = util::exp_decay_rate_from_half_life(half_life);
         return vaccine_protection[strain] * util::exp_decay(waning_rate, time);
     } else {
         return vaccine_protection[strain];

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -102,9 +102,15 @@ double Person::get_remaining_vaccine_protection(StrainType strain, size_t time) 
         const auto half_life = (strain == INFLUENZA)
                                    ? par->get("flu_vax_effect_half_life")
                                    : par->get("nonflu_vax_effect_half_life");
+        const auto waning_lag = (strain == INFLUENZA)
+                                    ? par->get("flu_vax_effect_lag_til_waning")
+                                    : par->get("nonflu_vax_effect_lag_til_waning");
+
         const auto waning_rate    = util::exp_decay_rate_from_half_life(half_life);
-        const auto time_since_vax = time - vaccination_time;
-        return vaccine_protection[strain] * util::exp_decay(waning_rate, time);
+        const auto time_since_vax = time - (vaccination_time + waning_lag);
+        return (time_since_vax < 0)
+               ? vaccine_protection[strain]
+               : vaccine_protection[strain] * util::exp_decay(waning_rate, time_since_vax);
     } else {
         return vaccine_protection[strain];
     }

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -50,6 +50,45 @@ size_t Person::get_id() const { return id; }
 double Person::get_susceptibility(StrainType strain) const { return susceptibility[strain]; }
 void Person::set_susceptibility(StrainType strain, double s) { susceptibility[strain] = s; }
 
+double Person::get_current_susceptibility(StrainType strain, size_t time) const {
+    bool immunity_generated = (strain == INFLUENZA)
+                                  ? par->get("flu_inf_gen_immunity")
+                                  : par->get("nonflu_inf_gen_immunity");
+
+    bool immunity_wanes = (strain == INFLUENZA)
+                              ? par->get("flu_inf_immunity_wanes")
+                              : par->get("nonflu_inf_immunity_wanes");
+
+    if (has_been_infected_with(strain)) {
+        if (immunity_generated and immunity_wanes) {
+            const auto half_life = (strain == INFLUENZA)
+                                       ? par->get("flu_inf_immunity_half_life")
+                                       : par->get("nonflu_inf_immunity_half_life");
+
+            const auto waning_rate = util::exp_decay_rate_from_half_life(half_life);
+
+            const auto refactory_period = (strain == INFLUENZA)
+                                              ? par->get("flu_inf_refact_len")
+                                              : par->get("nonflu_inf_refact_len");
+
+            // this starts waning only after the refactory period length
+            // during the refactory period, suscep will be negative though this
+            // wont matter because is_susceptible_to() is false during the refactory period
+            const auto time_since_last_inf = time - (most_recent_infection(strain)->get_infection_time() + refactory_period);
+
+            // 1 - exp flips the decay and will allow suscep to rise from zero to its original value
+            return susceptibility[strain] * (1 - util::exp_decay(waning_rate, time_since_last_inf));
+        } else {
+            // if immunity is generated and doesnt wane, the individual is perfectly protected forever (suscep = 0)
+            // otherwise, when no immunity is generated, they have constant susceptibility
+            return (immunity_generated) ? 0 : susceptibility[strain];
+        }
+    } else {
+        // when no immunity is generated, the individual has constant susceptibility
+        return susceptibility[strain];
+    }
+}
+
 double Person::get_vaccine_protection(StrainType strain) const { return vaccine_protection[strain]; }
 void Person::set_vaccine_protection(StrainType strain, double vp) { vaccine_protection[strain] = vp; }
 
@@ -66,8 +105,8 @@ const std::vector<std::unique_ptr<Infection>>& Person::get_infection_history() c
 
 Infection* Person::attempt_infection(StrainType strain, size_t time) {
     Infection* inf = nullptr;
-    if (is_susceptible_to(strain)) {
-        auto current_suscep = susceptibility[strain];
+    if (is_susceptible_to(strain, time)) {
+        auto current_suscep = get_current_susceptibility(strain, time);
         current_suscep *= is_vaccinated() ? 1 - get_remaining_vaccine_protection(strain, time) : 1;
 
         if (rng->draw_from_rng(INFECTION) < current_suscep) {
@@ -108,22 +147,44 @@ bool Person::has_been_infected_with(StrainType strain) const {
 
 bool Person::is_vaccinated() const { return vaccination_status == VACCINATED; }
 
-bool Person::is_susceptible_to(StrainType strain) const {
-    switch (strain) {
-        case INFLUENZA: {
-            return not has_been_infected_with(INFLUENZA);
+bool Person::is_susceptible_to(StrainType strain, size_t time) const {
+    // if within any infection refactory period, return false
+    const auto last_inf = most_recent_infection();
+    if (last_inf != nullptr) {
+        const auto time_since_last_inf = time - last_inf->get_infection_time();
+
+        double refactory_period = 0;
+        switch (last_inf->get_strain()) {
+            case INFLUENZA: { refactory_period = par->get("flu_inf_refact_len"); break; }
+            case NON_INFLUENZA: { refactory_period = par->get("nonflu_inf_refact_len"); break; }
+            default: { break; }
         }
-        case NON_INFLUENZA:
-            [[fallthrough]];
-        default:
-            return true;
+
+        if (time_since_last_inf < refactory_period) { return false; }
     }
+
+    // if current suscep <= 0, return false
+    if (get_current_susceptibility(strain, time) <= 0) { return false; }
+
+    // otherwise, return true
+    return true;
 }
 
 Infection* Person::most_recent_infection() const {
     auto inf = has_been_infected() ? infection_history.back().get() : nullptr;
     return inf;
 }
+
+Infection* Person::most_recent_infection(StrainType strain) const {
+    auto itr = std::find_if(infection_history.crbegin(),
+                            infection_history.crend(),
+                            [strain](const std::unique_ptr<Infection>& i) { return i->get_strain() == strain; });
+
+    return (itr != infection_history.crend()) ? itr->get() : nullptr;
+}
+
+size_t Person::last_infection_time() const { return most_recent_infection()->get_infection_time(); }
+size_t Person::last_infection_strain() const { return most_recent_infection()->get_strain(); }
 
 std::ostream& operator<<(std::ostream& o, const Person& p) {
     return o << "Person ID: " << p.id << '\n'

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -71,9 +71,10 @@ void Simulator::results() {
     // retrieve desired metrics
     if (sim_flags["verbose"]) {
         if (sim_flags.at("very_verbose")) {
-            std::cerr << "t\tc_vaxflu_mais\tc_unvaxflu_mais\tc_vaxnflu_mais\tc_unvaxnflu_mais\ttnd_ve\n";
+            std::cerr << "t\tpr_exposure(flu|nflu)\tc_vaxflu_mais\tc_unvaxflu_mais\tc_vaxnflu_mais\tc_unvaxnflu_mais\ttnd_ve\n";
             for (size_t t = 0; t < par->get("sim_duration"); ++t) {
                 std::cerr << t << '\t'
+                          << par->strain_probs[t][INFLUENZA] << " | " << par->strain_probs[t][NON_INFLUENZA] << "\t\t"
                           << ledger->get_cumul_mais(VACCINATED, INFLUENZA, t) << "\t\t"
                           << ledger->get_cumul_mais(UNVACCINATED, INFLUENZA, t) << "\t\t"
                           << ledger->get_cumul_mais(VACCINATED, NON_INFLUENZA, t) << "\t\t"

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -17,6 +17,7 @@
 namespace constants {
     unsigned int ZERO = 0;
     unsigned int ONE = 1;
+    double PI = 3.14159265358979323846;
 }
 
 namespace util {

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -65,11 +65,19 @@ namespace util {
     }
 
     double logistic(const double log_odds) {
-      return 1 / (1 + std::exp(-1.0 * log_odds));
+        return 1 / (1 + std::exp(-1.0 * log_odds));
     }
 
     double logit(const double prob) {
-      return std::log(prob / (1 - prob));
+        return std::log(prob / (1 - prob));
+    }
+
+    double exp_decay_rate_from_half_life(const double half_life) {
+        return std::log(2) / half_life;
+    }
+
+    double exp_decay(const double rate, const double time) {
+        return std::exp(-1 * rate * time);
     }
 }
 


### PR DESCRIPTION
Implemented time-varying daily exposure probability (PR #14)
- Seasonal forcing is implemented using a simple sinusoidal function with user-parameterized amplitude multiplier, period, and phase shift
- Daily exposure probability is added to the simulation dashboard

Implemented waning vaccine-derived protection (PR #15 + bugfixes)
- The user specifies the half-life of vaccine efficacy and the model implements an exponential waning model with a rate to generate that half-life
- Bugfix: vaccine efficacy waning is now strain-specific with strain-specific user parameterization
- ~~TODO: allow for user-parameterized lag until waning begins~~
- Vaccine efficacy only begins to wane after a user-defined time lag

Implemented waning infection-derived protection (PR #16)
- Similar to vaccine efficacy waning, infection-derived protection wanes exponentially with a strain-specific user-parameterized half-life
- Additional user-defined parameters allows for more fine control over strain-specific immunity dynamics:
  - Infections can generate a refractory period during which the individual cannot be infected by any pathogen
  - Infections can generate strain-specific immunity after the refractory period or susceptibility immediately returns to its original value after the refractory period
  - If immunity is generated after the refractory period, it can exponentially wane with some half-life or remain constant over time.
- For example: the simple TND-like model of immunity uses the following models:
  - There is no refractory period after infection
  - Non-influenza infections do not generate immunity
  - Influenza infections generate immunity that does not wane over time